### PR TITLE
Bump packer version - change puppet-archive version

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,7 +11,7 @@ class packer::params {
 
   $base_url  = 'https://releases.hashicorp.com/packer'
   $ensure    = 'installed'
-  $version   = '1.0.0'
+  $version   = '1.1.2'
   $proxy     = undef
 
   case downcase($::kernel) {

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppet/archive",
-      "version_requirement": "0.3.0"
+      "version_requirement": ">= 1.0.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
I bumped the packer version to the most recent one, 1.1.2.
Furthermore I've changed the puppet-archive module version, since the mentioned version (0.3.0) is not available anymore.